### PR TITLE
updated maven dependices

### DIFF
--- a/stone/pom.xml
+++ b/stone/pom.xml
@@ -102,6 +102,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
+        
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
@@ -130,6 +131,16 @@
             <version>6.2.10</version>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
force update of dependency: org.apache.tomcat.embed to 10.1.44 to fix:

Package: org.apache.tomcat.embed:tomcat-embed-core
Installed Version: 10.1.43
Vulnerability CVE-2025-48989
Severity: HIGH
Fixed Version: 11.0.10, 10.1.44, 9.0.108